### PR TITLE
cmake: Bump dependency versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8)
 project(gr-radar CXX C)
 enable_testing()
 
@@ -36,7 +36,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 # Set C++ standard for all targets
 IF(CMAKE_VERSION VERSION_GREATER 3.1)
-    set(CMAKE_CXX_STANDARD 98)
+    set(CMAKE_CXX_STANDARD 11)
 ENDIF()
 
 # Set cmake policies.
@@ -79,7 +79,7 @@ set(Boost_ADDITIONAL_VERSIONS
     "1.60.0" "1.60" "1.61.0" "1.61" "1.62.0" "1.62" "1.63.0" "1.63" "1.64.0" "1.64"
     "1.65.0" "1.65" "1.66.0" "1.66" "1.67.0" "1.67" "1.68.0" "1.68" "1.69.0" "1.69"
 )
-find_package(Boost "1.35" COMPONENTS filesystem system)
+find_package(Boost "1.53" COMPONENTS filesystem system)
 
 if(NOT Boost_FOUND)
     message(FATAL_ERROR "Boost required to compile radar")

--- a/lib/estimator_cw_impl.h
+++ b/lib/estimator_cw_impl.h
@@ -46,7 +46,7 @@ namespace gr {
 	  pmt::pmt_t d_vel_key, d_vel_value, d_vel_pack, d_value;
 	  pmt::pmt_t d_time_key, d_time_value, d_time_pack;
       
-      const static float c_light = 3e8;
+      constexpr static float c_light = 3e8;
     };
 
   } // namespace radar

--- a/lib/estimator_fmcw_impl.h
+++ b/lib/estimator_fmcw_impl.h
@@ -52,7 +52,7 @@ namespace gr {
       pmt::pmt_t d_port_id_in_cw, d_port_id_in_up, d_port_id_in_down, d_port_id_out;
       pmt::pmt_t d_msg_cw, d_msg_up, d_msg_down;
       
-      const static float c_light = 3e8;
+      constexpr static float c_light = 3e8;
 
     };
 

--- a/lib/estimator_fsk_impl.h
+++ b/lib/estimator_fsk_impl.h
@@ -49,7 +49,7 @@ namespace gr {
 	  std::vector<float> d_range;
 	  pmt::pmt_t d_range_key, d_range_value, d_range_pack;
       
-      const static float c_light = 3e8;
+      constexpr static float c_light = 3e8;
       
     };
 

--- a/lib/estimator_rcs_impl.h
+++ b/lib/estimator_rcs_impl.h
@@ -58,7 +58,7 @@ namespace gr {
       std::vector<float> d_range, d_power, d_rcs;
       std::vector<pmt::pmt_t> d_msg_hold;
 
-      const static float c_light = 3e8;
+      constexpr static float c_light = 3e8;
 
     };
 

--- a/lib/static_target_simulator_cc_impl.h
+++ b/lib/static_target_simulator_cc_impl.h
@@ -90,7 +90,7 @@ namespace gr {
       uint64_t d_time_sec;
       double d_time_frac_sec;
 
-      const static float c_light = 3e8;
+      constexpr static float c_light = 3e8;
 
       // Where all the action really happens
       int work(int noutput_items,


### PR DESCRIPTION
- C++11
- Boost 1.53
- CMake 2.8

Note: Going to C++11 requires some small changes in some of the headers.