### PR TITLE
static_target_simulator: Fix attenuation coefficient (square c_0)

### DIFF
--- a/include/radar/static_target_simulator_cc.h
+++ b/include/radar/static_target_simulator_cc.h
@@ -51,7 +51,7 @@ namespace gr {
          * cross section \f$\sigma_{\text{RCS},h}\f$, the distance of the target
          * \f$d_h\f$ and the speed of light \f$c_0\f$:
          * \f[
-         *     b_h = \sqrt{\frac{c_0 \sigma_{\text{RCS},h}}{(4\pi)^3 d_h^4 f_C^2}}
+         *     b_h = \sqrt{\frac{c_0^2 \sigma_{\text{RCS},h}}{(4\pi)^3 d_h^4 f_C^2}}
          * \f]
          *
          * The delay \f$\tau_h\f$ depends on the distance of the target:

--- a/lib/static_target_simulator_cc_impl.cc
+++ b/lib/static_target_simulator_cc_impl.cc
@@ -132,8 +132,8 @@ namespace gr { namespace radar {
         d_scale_ampl.resize(d_num_targets);
         for (int k = 0; k < d_num_targets; k++) {
             // Factor out all terms out of the sqrt except the RCS:
-            d_scale_ampl[k] =
-                std::sqrt(c_light * d_rcs[k])
+            d_scale_ampl[k] = c_light
+                * std::sqrt(d_rcs[k])
                 / FOUR_PI_CUBED_SQRT
                 / (d_range[k] * d_range[k])
                 / d_center_freq;


### PR DESCRIPTION
This reverts 2b7662c8166d920cef0c5a9a619f3a171fa4e869, but we keep the
formatting changes.